### PR TITLE
Add devbox + compose-managed dev environment with seed data

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,5 @@
+DATABASE_URL=postgresql://postgres:password@localhost:5432/mario_kart
+JWT_SECRET=change-me-in-production-at-least-32-characters-long
+SERVER_HOST=0.0.0.0
+SERVER_PORT=8080
+ENABLE_PLAYGROUND=true

--- a/backend/README.md
+++ b/backend/README.md
@@ -23,6 +23,10 @@ A Rust GraphQL API backend for tracking Mario Kart tournament leaderboards with 
 cargo install sqlx-cli --no-default-features --features postgres
 ```
 
+### Optional: devbox
+
+If you have [devbox](https://www.jetpack.io/devbox) installed, `devbox shell` from the repo root provides pinned versions of Rust, Node, `pnpm`, and `sqlx-cli` without needing to install any of them manually. First invocation warms the Nix store and can take several minutes; subsequent shells are near-instant.
+
 ## Setup
 
 ### 1. Environment Configuration
@@ -39,6 +43,8 @@ ENABLE_PLAYGROUND=true
 
 ### 2. Database Setup
 
+#### Option A: Install Postgres locally
+
 Create the database:
 
 ```bash
@@ -48,6 +54,24 @@ createdb mario_kart
 # Or using SQL
 psql -U postgres -c "CREATE DATABASE mario_kart;"
 ```
+
+#### Option B: Run Postgres via Docker Compose
+
+Alternatively, start the bundled Postgres 16 service from `backend/docker-compose.yml`:
+
+```bash
+docker compose -f backend/docker-compose.yml up -d postgres
+# or, if you prefer Podman:
+podman compose -f backend/docker-compose.yml up -d postgres
+```
+
+Then copy the matching `.env` template:
+
+```bash
+cp .env.example .env
+```
+
+The credentials in `.env.example` match the compose service defaults. Data is persisted in the named volume `mario-kart-pgdata`; use `docker compose ... down -v` to wipe it. If port `5432` is already taken by a host-native Postgres, stop that service first or change the host port mapping in `docker-compose.yml` and update `DATABASE_URL` in your `.env` accordingly.
 
 ### 3. Run Migrations
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -73,6 +73,8 @@ cp .env.example .env
 
 The credentials in `.env.example` match the compose service defaults. Data is persisted in the named volume `mario-kart-pgdata`; use `docker compose ... down -v` to wipe it. If port `5432` is already taken by a host-native Postgres, stop that service first or change the host port mapping in `docker-compose.yml` and update `DATABASE_URL` in your `.env` accordingly.
 
+Prefer a single command? If you have `devbox` installed, `devbox run db:bootstrap` starts Postgres, runs migrations, and seeds a sample group (`Dev Group` / `devpassword`) with four players (`Mario`, `Luigi`, `Peach`, `Bowser`). It is idempotent — safe to re-run. The seed prints an auto-login URL you can paste into the browser (`http://localhost:5173/?groupId=...&password=...`), plus a JWT for the GraphQL playground.
+
 ### 3. Run Migrations
 
 Run all pending migrations:

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -12,3 +12,24 @@ services:
       # Maps host 4317 -> container 18889
       - "4317:18889"
     restart: unless-stopped
+
+  postgres:
+    image: postgres:16-alpine
+    container_name: mario-kart-postgres
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: mario_kart
+    ports:
+      - "5432:5432"
+    volumes:
+      - mario-kart-pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 2s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+volumes:
+  mario-kart-pgdata:

--- a/backend/src/bin/seed.rs
+++ b/backend/src/bin/seed.rs
@@ -48,12 +48,29 @@ async fn main() -> Result<()> {
         }
         None => {
             let hash = hash_password(&group_password)?;
-            let created = Group::create(&pool, &group_name, &hash).await?;
-            println!(
-                "seed: created group '{}' with id {}",
-                group_name, created.id
-            );
-            created
+            match Group::create(&pool, &group_name, &hash).await {
+                Ok(created) => {
+                    println!(
+                        "seed: created group '{}' with id {}",
+                        group_name, created.id
+                    );
+                    created
+                }
+                Err(sqlx::Error::Database(db_err)) if db_err.is_unique_violation() => {
+                    let found = Group::find_by_name(&pool, &group_name).await?.ok_or_else(|| {
+                        AppError::InvalidInput(format!(
+                            "groups.name unique violation but no matching row for '{}' — check for whitespace or casing in the stored value",
+                            group_name
+                        ))
+                    })?;
+                    println!(
+                        "seed: group '{}' already exists — reusing id {}",
+                        group_name, found.id
+                    );
+                    found
+                }
+                Err(e) => return Err(e.into()),
+            }
         }
     };
 

--- a/backend/src/bin/seed.rs
+++ b/backend/src/bin/seed.rs
@@ -71,8 +71,21 @@ async fn main() -> Result<()> {
     }
 
     let token = create_jwt(group.id, &jwt_secret)?;
-    println!("\nGROUP_ID: {}", group.id);
-    println!("JWT: {}", token);
+    let frontend_url =
+        env::var("FRONTEND_URL").unwrap_or_else(|_| "http://localhost:5173".to_string());
+
+    println!(
+        "\nAuto-login URL:\n  {}/?groupId={}&password={}",
+        frontend_url, group.id, group_password,
+    );
+    println!(
+        "\nOr log in manually at {}/login with:\n  group id: {}\n  password: {}",
+        frontend_url, group.id, group_password,
+    );
+    println!(
+        "\nJWT (for the GraphQL playground at http://localhost:8080/):\n  {}",
+        token,
+    );
 
     Ok(())
 }

--- a/backend/src/bin/seed.rs
+++ b/backend/src/bin/seed.rs
@@ -1,7 +1,8 @@
+use chrono::{Duration, Local};
 use mario_kart_leaderboard_backend::{
     auth::{create_jwt, hash_password},
     error::{AppError, Result},
-    models::{Group, Player},
+    models::{Group, Player, Tournament},
     services::validation::{validate_name, validate_password},
 };
 use sqlx::postgres::PgPoolOptions;
@@ -85,6 +86,22 @@ async fn main() -> Result<()> {
         }
         Player::create(&pool, group.id, name).await?;
         println!("seed: created player '{}'", name);
+    }
+
+    let existing_tournaments = Tournament::find_by_group_id(&pool, group.id).await?;
+    if existing_tournaments.is_empty() {
+        let today = Local::now().date_naive();
+        let end = today + Duration::days(30);
+        let tournament = Tournament::create(&pool, group.id, Some(today), Some(end)).await?;
+        println!(
+            "seed: created tournament {} ({} → {})",
+            tournament.id, today, end
+        );
+    } else {
+        println!(
+            "seed: group already has {} tournament(s) — skipping",
+            existing_tournaments.len()
+        );
     }
 
     let token = create_jwt(group.id, &jwt_secret)?;

--- a/backend/src/bin/seed.rs
+++ b/backend/src/bin/seed.rs
@@ -1,0 +1,78 @@
+use mario_kart_leaderboard_backend::{
+    auth::{create_jwt, hash_password},
+    error::{AppError, Result},
+    models::{Group, Player},
+    services::validation::{validate_name, validate_password},
+};
+use sqlx::postgres::PgPoolOptions;
+use std::{collections::HashSet, env};
+
+const DEFAULT_GROUP_NAME: &str = "Dev Group";
+const DEFAULT_GROUP_PASSWORD: &str = "devpassword";
+const PLAYER_NAMES: &[&str] = &["Mario", "Luigi", "Peach", "Bowser"];
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    dotenv::dotenv().ok();
+
+    let database_url = env::var("DATABASE_URL").map_err(|_| {
+        AppError::InvalidInput("DATABASE_URL not set — configure backend/.env".to_string())
+    })?;
+    let jwt_secret = env::var("JWT_SECRET").map_err(|_| {
+        AppError::InvalidInput("JWT_SECRET not set — configure backend/.env".to_string())
+    })?;
+
+    let group_name =
+        env::var("SEED_GROUP_NAME").unwrap_or_else(|_| DEFAULT_GROUP_NAME.to_string());
+    let group_password =
+        env::var("SEED_GROUP_PASSWORD").unwrap_or_else(|_| DEFAULT_GROUP_PASSWORD.to_string());
+
+    validate_name(&group_name, "Group name")?;
+    validate_password(&group_password)?;
+
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&database_url)
+        .await?;
+
+    println!("seed: connecting to database … ok");
+    println!("seed: ⚠️  dev data only — do NOT run against production");
+
+    let group = match Group::find_by_name(&pool, &group_name).await? {
+        Some(existing) => {
+            println!(
+                "seed: group '{}' already exists — reusing id {}",
+                group_name, existing.id
+            );
+            existing
+        }
+        None => {
+            let hash = hash_password(&group_password)?;
+            let created = Group::create(&pool, &group_name, &hash).await?;
+            println!(
+                "seed: created group '{}' with id {}",
+                group_name, created.id
+            );
+            created
+        }
+    };
+
+    let existing_players = Player::find_by_group_id(&pool, group.id).await?;
+    let existing_names: HashSet<&str> =
+        existing_players.iter().map(|p| p.name.as_str()).collect();
+
+    for name in PLAYER_NAMES {
+        if existing_names.contains(*name) {
+            println!("seed: player '{}' already exists — skipping", name);
+            continue;
+        }
+        Player::create(&pool, group.id, name).await?;
+        println!("seed: created player '{}'", name);
+    }
+
+    let token = create_jwt(group.id, &jwt_secret)?;
+    println!("\nGROUP_ID: {}", group.id);
+    println!("JWT: {}", token);
+
+    Ok(())
+}

--- a/devbox.json
+++ b/devbox.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/main/.schema/devbox.schema.json",
+  "packages": [
+    "rustup@latest",
+    "nodejs@22",
+    "pnpm@10.20.0",
+    "sqlx-cli@latest"
+  ],
+  "shell": {
+    "init_hook": [
+      "echo \"devbox shell active — run 'devbox run help' for shortcuts\""
+    ],
+    "scripts": {
+      "help": [
+        "echo 'Available devbox scripts:'",
+        "echo '  db:up        Start Postgres via docker compose'",
+        "echo '  db:down      Stop Postgres'",
+        "echo '  db:logs      Tail Postgres logs'",
+        "echo '  migrate      Run backend migrations'",
+        "echo '  dev:backend  Run backend dev server'",
+        "echo '  dev:frontend Run frontend dev server'"
+      ],
+      "db:up": "docker compose -f backend/docker-compose.yml up -d postgres",
+      "db:down": "docker compose -f backend/docker-compose.yml down",
+      "db:logs": "docker compose -f backend/docker-compose.yml logs -f postgres",
+      "migrate": "cd backend && cargo run --bin migrate up",
+      "dev:backend": "cd backend && cargo run",
+      "dev:frontend": "cd frontend && pnpm dev"
+    }
+  }
+}

--- a/devbox.json
+++ b/devbox.json
@@ -13,19 +13,23 @@
     "scripts": {
       "help": [
         "echo 'Available devbox scripts:'",
-        "echo '  db:up        Start Postgres via docker compose'",
+        "echo '  db:bootstrap Start Postgres, run migrations, and seed dev data'",
+        "echo '  db:up        Start Postgres (waits until healthy)'",
         "echo '  db:down      Stop Postgres (preserves data)'",
         "echo '  db:reset     Stop Postgres and wipe the data volume'",
         "echo '  db:logs      Tail Postgres logs'",
         "echo '  migrate      Run backend migrations'",
+        "echo '  seed         Seed the dev DB with a sample group and players'",
         "echo '  dev:backend  Run backend dev server'",
         "echo '  dev:frontend Run frontend dev server'"
       ],
-      "db:up": "docker compose -f backend/docker-compose.yml up -d postgres",
+      "db:up": "docker compose -f backend/docker-compose.yml up -d --wait postgres",
       "db:down": "docker compose -f backend/docker-compose.yml down",
       "db:reset": "docker compose -f backend/docker-compose.yml down -v",
       "db:logs": "docker compose -f backend/docker-compose.yml logs -f postgres",
       "migrate": "cd backend && cargo run --bin migrate up",
+      "seed": "cd backend && cargo run --bin seed",
+      "db:bootstrap": "docker compose -f backend/docker-compose.yml up -d --wait postgres && cd backend && cargo run --bin migrate up && cargo run --bin seed",
       "dev:backend": "cd backend && cargo run --bin mario-kart-leaderboard-backend",
       "dev:frontend": "cd frontend && pnpm dev"
     }

--- a/devbox.json
+++ b/devbox.json
@@ -1,10 +1,10 @@
 {
   "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/main/.schema/devbox.schema.json",
   "packages": [
-    "rustup@latest",
+    "rustup@1.29.0",
     "nodejs@22",
     "pnpm@10.20.0",
-    "sqlx-cli@latest"
+    "sqlx-cli@0.8.6"
   ],
   "shell": {
     "init_hook": [
@@ -14,7 +14,8 @@
       "help": [
         "echo 'Available devbox scripts:'",
         "echo '  db:up        Start Postgres via docker compose'",
-        "echo '  db:down      Stop Postgres'",
+        "echo '  db:down      Stop Postgres (preserves data)'",
+        "echo '  db:reset     Stop Postgres and wipe the data volume'",
         "echo '  db:logs      Tail Postgres logs'",
         "echo '  migrate      Run backend migrations'",
         "echo '  dev:backend  Run backend dev server'",
@@ -22,6 +23,7 @@
       ],
       "db:up": "docker compose -f backend/docker-compose.yml up -d postgres",
       "db:down": "docker compose -f backend/docker-compose.yml down",
+      "db:reset": "docker compose -f backend/docker-compose.yml down -v",
       "db:logs": "docker compose -f backend/docker-compose.yml logs -f postgres",
       "migrate": "cd backend && cargo run --bin migrate up",
       "dev:backend": "cd backend && cargo run --bin mario-kart-leaderboard-backend",

--- a/devbox.json
+++ b/devbox.json
@@ -24,7 +24,7 @@
       "db:down": "docker compose -f backend/docker-compose.yml down",
       "db:logs": "docker compose -f backend/docker-compose.yml logs -f postgres",
       "migrate": "cd backend && cargo run --bin migrate up",
-      "dev:backend": "cd backend && cargo run",
+      "dev:backend": "cd backend && cargo run --bin mario-kart-leaderboard-backend",
       "dev:frontend": "cd frontend && pnpm dev"
     }
   }

--- a/devbox.lock
+++ b/devbox.lock
@@ -102,7 +102,7 @@
         }
       }
     },
-    "rustup@latest": {
+    "rustup@1.29.0": {
       "last_modified": "2026-04-01T01:09:41Z",
       "plugin_version": "0.0.1",
       "resolved": "github:NixOS/nixpkgs/62e3050a29278c985725a86704faa1e99236b51a#rustup",
@@ -151,7 +151,7 @@
         }
       }
     },
-    "sqlx-cli@latest": {
+    "sqlx-cli@0.8.6": {
       "last_modified": "2026-03-21T07:29:51Z",
       "resolved": "github:NixOS/nixpkgs/09061f748ee21f68a089cd5d91ec1859cd93d0be#sqlx-cli",
       "source": "devbox-search",

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,0 +1,203 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "last_modified": "2026-03-23T13:48:00Z",
+      "resolved": "github:NixOS/nixpkgs/fdc7b8f7b30fdbedec91b71ed82f36e1637483ed?lastModified=1774273680&narHash=sha256-a%2B%2BtZ1RQsDb1I0NHrFwdGuRlR5TORvCEUksM459wKUA%3D"
+    },
+    "nodejs@22": {
+      "last_modified": "2026-04-16T08:46:55Z",
+      "plugin_version": "0.0.2",
+      "resolved": "github:NixOS/nixpkgs/b86751bc4085f48661017fa226dee99fab6c651b#nodejs_22",
+      "source": "devbox-search",
+      "version": "22.22.2",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/jp1j44w4fvrxvx62fasairgwv80iw6x3-nodejs-22.22.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/jp1j44w4fvrxvx62fasairgwv80iw6x3-nodejs-22.22.2"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/8h77mdsa9py3x9xxx2yak50fl6kqf2ma-nodejs-22.22.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/8h77mdsa9py3x9xxx2yak50fl6kqf2ma-nodejs-22.22.2"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/xn66x7bs1winnfa4pakr9lrjamb9bmj3-nodejs-22.22.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/xn66x7bs1winnfa4pakr9lrjamb9bmj3-nodejs-22.22.2"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/h2barca1k5pmvcyl9fwrzwrb4cn1b248-nodejs-22.22.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/h2barca1k5pmvcyl9fwrzwrb4cn1b248-nodejs-22.22.2"
+        }
+      }
+    },
+    "pnpm@10.20.0": {
+      "last_modified": "2025-10-30T18:40:41Z",
+      "resolved": "github:NixOS/nixpkgs/45ebaee5d90bab997812235564af4cf5107bde89#pnpm",
+      "source": "devbox-search",
+      "version": "10.20.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/zxr2z04s11vsmdx5ybdnyld2kllvlq61-pnpm-10.20.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/zxr2z04s11vsmdx5ybdnyld2kllvlq61-pnpm-10.20.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/n16klspqw8n1zlgfmjy8nh861d3mfqn4-pnpm-10.20.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/n16klspqw8n1zlgfmjy8nh861d3mfqn4-pnpm-10.20.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/hcapz1vmdymmxk35z564jsmskvdphpp1-pnpm-10.20.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/hcapz1vmdymmxk35z564jsmskvdphpp1-pnpm-10.20.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/1bwlymbmhvc5qhvc4jnry443jizqrm20-pnpm-10.20.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/1bwlymbmhvc5qhvc4jnry443jizqrm20-pnpm-10.20.0"
+        }
+      }
+    },
+    "rustup@latest": {
+      "last_modified": "2026-04-01T01:09:41Z",
+      "plugin_version": "0.0.1",
+      "resolved": "github:NixOS/nixpkgs/62e3050a29278c985725a86704faa1e99236b51a#rustup",
+      "source": "devbox-search",
+      "version": "1.29.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/vf4ymfv40jsq1r2bapps3ll8xxqng794-rustup-1.29.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/vf4ymfv40jsq1r2bapps3ll8xxqng794-rustup-1.29.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/q335jx3dgagxcj79bgxaxa027bq3vf7a-rustup-1.29.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/q335jx3dgagxcj79bgxaxa027bq3vf7a-rustup-1.29.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/psqiilmbpc0d5c12qpswamkhdgzq5dcv-rustup-1.29.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/psqiilmbpc0d5c12qpswamkhdgzq5dcv-rustup-1.29.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/3jmhpvfwqag9jcxi21l2lrv79ha7h4p5-rustup-1.29.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/3jmhpvfwqag9jcxi21l2lrv79ha7h4p5-rustup-1.29.0"
+        }
+      }
+    },
+    "sqlx-cli@latest": {
+      "last_modified": "2026-03-21T07:29:51Z",
+      "resolved": "github:NixOS/nixpkgs/09061f748ee21f68a089cd5d91ec1859cd93d0be#sqlx-cli",
+      "source": "devbox-search",
+      "version": "0.8.6",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/rzdcvyf9fmfa9kqhgcx4s0ffa7abb0q1-sqlx-cli-0.8.6",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/rzdcvyf9fmfa9kqhgcx4s0ffa7abb0q1-sqlx-cli-0.8.6"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/kbjhb5y5nrasmn0jhfmz598d8av90418-sqlx-cli-0.8.6",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/kbjhb5y5nrasmn0jhfmz598d8av90418-sqlx-cli-0.8.6"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/y9skl9alqsjv2q34mx15gqkbyfh764kh-sqlx-cli-0.8.6",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/y9skl9alqsjv2q34mx15gqkbyfh764kh-sqlx-cli-0.8.6"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/bhs0ngqz08zjzpfrzfa4z6n068qnxlg2-sqlx-cli-0.8.6",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/bhs0ngqz08zjzpfrzfa4z6n068qnxlg2-sqlx-cli-0.8.6"
+        }
+      }
+    }
+  }
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.95.0"
+components = ["rustfmt", "clippy"]
+profile = "default"


### PR DESCRIPTION
## Summary

Adds an **optional** reproducible dev environment on top of the existing host-Postgres + Podman workflow. Nothing existing is removed — the current setup still works as-is.

### Tooling
- Pin Rust (1.95.0 via `rust-toolchain.toml`), Node 22, pnpm 10.20.0, and sqlx-cli 0.8.6 via `devbox.json`. `devbox shell` gives a reproducible toolchain; first run warms the Nix store, subsequent shells are instant.
- Add a containerized Postgres 16 service to `backend/docker-compose.yml` alongside the existing Aspire dashboard. Named volume persists data; `devbox run db:reset` wipes it.
- Add `backend/.env.example` matching the compose defaults so new contributors can `cp .env.example .env`.

### Seed + bootstrap
- New `backend/src/bin/seed.rs` — idempotent seed that creates `Dev Group` (password `devpassword`), four players (`Mario`, `Luigi`, `Peach`, `Bowser`), and one tournament (today → +30 days). Reuses the existing `Group::create` / `Player::create` / `hash_password` paths — no SQL drift.
- New `devbox run db:bootstrap` one-shot: starts Postgres (with `--wait`), runs migrations, seeds. Prints an auto-login URL (`/?groupId=…&password=…`), manual-login credentials, and a JWT for the GraphQL playground.

### Docs
- Additive updates to `backend/README.md` — new devbox subsection under Prerequisites, "Option B: Docker Compose" under Database Setup, and a one-liner describing `db:bootstrap`. Existing Podman / host-Postgres guidance stays.

## Test plan
- [ ] `devbox shell` resolves Rust 1.95.0, Node 22, pnpm 10.20.0, sqlx-cli 0.8.6
- [ ] `devbox run db:reset && devbox run db:bootstrap` → 1 group, 4 players, 1 tournament
- [ ] `devbox run db:bootstrap` (re-run) → all "already exists" messages, counts unchanged
- [ ] Auto-login URL in seed output logs you into the frontend in one click
- [ ] Existing `cargo test -- --test-threads=1` still passes against Docker/Podman
- [ ] Existing host-Postgres + manual `.env` flow still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)