### PR TITLE
fix(frontend): re-sync CreateMatchModal selection with lobby on every open

### DIFF
--- a/frontend/src/components/CreateMatchModal.tsx
+++ b/frontend/src/components/CreateMatchModal.tsx
@@ -25,19 +25,14 @@ export const CreateMatchModal = (dependencies: { open: boolean; onOpenChange: (o
 
   const playerSelection = usePlayerSelection(initialSelectedIds)
 
-  // Re-seed selection while it is still empty: covers both the initial open
-  // (selection starts empty until `initialSelectedIds` is non-empty) and the
-  // case where the lobby query is still in-flight when the modal first opens
-  // — once the lobby data arrives, the empty selection picks it up. As soon
-  // as the user toggles any player, the selection becomes non-empty and is
-  // no longer overwritten by lobby refetches mid-edit.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: setSelection is stable, playerSelection.selectedPlayerIds is read at effect time
+  // The modal is mounted for the lifetime of the page (see Home.tsx), so its
+  // `useState`-based selection would otherwise stick to whatever the lobby
+  // looked like at first mount. Re-seed from the current lobby on every
+  // closed→open transition.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally only re-syncs on open transition; mid-session lobby refetches must not overwrite user edits
   useEffect(() => {
-    if (!open) return
-    if (playerSelection.selectedPlayerIds.length > 0) return
-    if (initialSelectedIds.length === 0) return
-    playerSelection.setSelection(initialSelectedIds)
-  }, [open, initialSelectedIds])
+    if (open) playerSelection.setSelection(initialSelectedIds)
+  }, [open])
   const { createMatchWithRounds, isCreatingMatch } = useMatchManagement()
 
   const playersPerRace = Number.parseInt(formState.playersPerRace, 10) || FALLBACK_PLAYERS_PER_RACE


### PR DESCRIPTION
## Summary
- Fix a stale-selection bug in **Create Race** where, after updating the lobby (e.g. another player checks in), the first time the modal opens it shows the lobby snapshot from when the page loaded rather than the current lobby. Closing and reopening worked because `handleClose` cleared the selection.
- Root cause: `CreateMatchModal` is mounted for the page's lifetime in `Home.tsx`, so `usePlayerSelection`'s `useState(initialSelectedIds)` only captured the lobby at first mount. The previous re-seed effect bailed out whenever the selection was non-empty, so subsequent lobby changes never made it into the modal until a close/clear cycle.
- Fix: re-seed `selectedPlayerIds` from `initialSelectedIds` on every closed→open transition so the modal always reflects the current lobby when it opens.

## Test plan
- [ ] With an active tournament and a populated lobby, open Create Race — the lobby's players are pre-selected.
- [ ] Close the modal, check a new player into the lobby, reopen Create Race — the new player is also pre-selected (previously stale).
- [ ] Close the modal, uncheck a player from the lobby, reopen — the unchecked player is no longer selected.
- [ ] Open Create Race, toggle players within the modal, submit — selection submitted matches user's edits (no overwrite from lobby refetches mid-session).